### PR TITLE
WIP radiasoft/devops#232: ipykernel is now installed in rscode-ipykernel

### DIFF
--- a/container-conf/build.sh
+++ b/container-conf/build.sh
@@ -97,26 +97,6 @@ beamsim_jupyter_rs_radia() {
     cd "$p"
 }
 
-beamsim_jupyter_ipy_kernel_env() {
-    # http://ipython.readthedocs.io/en/stable/install/kernel_install.html
-    # http://www.alfredo.motta.name/create-isolated-jupyter-ipython-kernels-with-pyenv-and-virtualenv/
-    local display_name=$1
-    local name=$2
-    local where=( $(python -m ipykernel install --display-name "$display_name" --name "$name" --user) )
-    PYENV_VERSION=$name perl -pi -e '
-        sub _e {
-            return join(
-                qq{,\n},
-                map(
-                    $ENV{$_} ? qq{  "$_": "$ENV{$_}"} : (),
-                    qw(LD_LIBRARY_PATH PKG_CONFIG_PATH PYENV_VERSION PYTHONPATH),
-                ),
-            );
-        }
-        s/^\{/{\n "env": {\n@{[_e()]}\n },/
-    ' "${where[-1]}"/kernel.json
-}
-
 beamsim_jupyter_rsbeams_style() {
     local dst
     local src
@@ -178,13 +158,9 @@ build_as_run_user() {
     export beamsim_jupyter_notebook_dir=$build_run_user_home/$notebook_dir_base
     export beamsim_jupyter_boot_dir
     export beamsim_jupyter_notebook_bashrc=$notebook_dir_base/bashrc
-    local i=3
-    local v=py$i
-    export beamsim_jupyter_jupyter_venv=$v
     export beamsim_jupyter_depot_server=$(install_depot_server)
     beamsim_jupyter_jupyterlab
     beamsim_jupyter_rsbeams_style
-    beamsim_jupyter_ipy_kernel_env "Python $i" "$v"
     mkdir -p "$beamsim_jupyter_notebook_dir"
     local f
     for f in ~/.jupyter/jupyter_notebook_config.py ~/.ipython/profile_default/ipython_config.py; do

--- a/container-conf/build.sh
+++ b/container-conf/build.sh
@@ -123,6 +123,7 @@ beamsim_jupyter_vars() {
 build_as_root() {
     umask 022
     local r=(
+        rscode-ipykernel
         # Needed for MPI nodes
         openssh-server
         # https://github.com/radiasoft/devops/issues/188

--- a/container-conf/radia-run.sh
+++ b/container-conf/radia-run.sh
@@ -5,8 +5,6 @@
 #
 cd
 source "$HOME"/.bashrc
-# POSIT: same env as kernel defined in rscode-ipykernel
-pyenv shell 'py3'
 curl {beamsim_jupyter_depot_server}/index.sh \
     | bash -s init-from-git radiasoft/jupyter.radiasoft.org
 # must be after to avoid false returns in bashrc, init-from-git, and pyenv

--- a/container-conf/radia-run.sh
+++ b/container-conf/radia-run.sh
@@ -5,7 +5,8 @@
 #
 cd
 source "$HOME"/.bashrc
-pyenv shell '{beamsim_jupyter_jupyter_venv}'
+# POSIT: same env as kernel defined in rscode-ipykernel
+pyenv shell 'py3'
 curl {beamsim_jupyter_depot_server}/index.sh \
     | bash -s init-from-git radiasoft/jupyter.radiasoft.org
 # must be after to avoid false returns in bashrc, init-from-git, and pyenv


### PR DESCRIPTION
This is needed so the kernel can be intalled in Sirepo to run
notebooks for the raydata app.