### PR TITLE
Fix #51: Upgrade to JupyterLab 3.x

### DIFF
--- a/container-conf/build.sh
+++ b/container-conf/build.sh
@@ -73,7 +73,7 @@ beamsim_jupyter_rs_radia() {
     local f
     local p=$(pwd)
     mkdir -p ~/src/radiasoft
-    for f in jupyter-rs-vtk jupyter-rs-radia; do
+    for f in jupyter_rs_vtk jupyter_rs_radia; do
 	cd ~/src/radiasoft
         git clone https://github.com/radiasoft/"$f"
         cd "$f"

--- a/container-conf/jupyter_server_config.py
+++ b/container-conf/jupyter_server_config.py
@@ -1,6 +1,7 @@
-c.KernelSpecManager.whitelist = {'py3', 'py2'}
-c.NotebookApp.terminado_settings = {
+c.KernelSpecManager.allowed_kernelspecs = {'py3', 'py2'}
+c.ServerApp.terminado_settings = {
     'shell_command': ['/bin/bash', '-l', '-i'],
 }
+
 # https://jupyterlab.readthedocs.io/en/stable/user/jupyterhub.html#use-jupyterlab-by-default
-c.NotebookApp.nbserver_extensions.jupyterlab = True
+c.Spawner.cmd=["jupyter-labhub"]


### PR DESCRIPTION
Dependencies were updated to support JupyterLab 3.x. In addition,
packages were moved to `pip install` to match the JupyterLab change
to prefer PyPi distribution of packages. Finally, install of our local
jupyter-rs-* packages was modified to work with the new structure.