### PR TITLE
Fix #54: use `jupyter labhub` to start jupyterlab

### DIFF
--- a/container-conf/jupyter_server_config.py
+++ b/container-conf/jupyter_server_config.py
@@ -2,6 +2,3 @@ c.KernelSpecManager.allowed_kernelspecs = {'py3', 'py2'}
 c.ServerApp.terminado_settings = {
     'shell_command': ['/bin/bash', '-l', '-i'],
 }
-
-# https://jupyterlab.readthedocs.io/en/stable/user/jupyterhub.html#use-jupyterlab-by-default
-c.Spawner.cmd=["jupyter-labhub"]

--- a/container-conf/jupyter_server_config.py
+++ b/container-conf/jupyter_server_config.py
@@ -1,4 +1,4 @@
-c.KernelSpecManager.allowed_kernelspecs = {'py3', 'py2'}
+c.KernelSpecManager.allowed_kernelspecs = {'py3'}
 c.ServerApp.terminado_settings = {
     'shell_command': ['/bin/bash', '-l', '-i'],
 }

--- a/container-conf/radia-run.sh
+++ b/container-conf/radia-run.sh
@@ -26,10 +26,6 @@ elif [[ ${JUPYTERHUB_API_URL:-} ]]; then
       --ip=0.0.0.0 \
       --KernelManager.transport=ipc \
       --notebook-dir="$PWD"
-    # TODO(e-carlin):  this is after exec, unreachable?
-    # Note that type -f is not executable, because of the way pyenv finds programs so
-    # this is only for error messages.
-    RADIA_RUN_CMD="$(type -f jupyter) lab"
 else
     # Start jupyter lab possibly with radia-run supplied token
     # urandom never blocks and is good enough for this case
@@ -49,5 +45,3 @@ EOF
     fi
     exec $RADIA_RUN_CMD
 fi
-echo "ERROR: '$RADIA_RUN_CMD': exec failed'" 1>&2
-exit 1

--- a/container-conf/radia-run.sh
+++ b/container-conf/radia-run.sh
@@ -21,12 +21,12 @@ elif [[ ${JUPYTERHUB_API_URL:-} ]]; then
     # https://github.com/jupyter/docker-stacks/tree/master/base-notebook for
     # why this is started this way.
     # POSIT: 8888 in various jupyterhub repos
-    exec jupyterhub-singleuser \
+    exec jupyter labhub \
       --port="${RADIA_RUN_PORT:-8888}" \
       --ip=0.0.0.0 \
       --KernelManager.transport=ipc \
-      --NotebookApp.default_url=/lab \
       --notebook-dir="$PWD"
+    # TODO(e-carlin):  this is after exec, unreachable?
     # Note that type -f is not executable, because of the way pyenv finds programs so
     # this is only for error messages.
     RADIA_RUN_CMD="$(type -f jupyter) lab"
@@ -39,7 +39,7 @@ else
     t=$(cat .radia-run-jupyter-token 2>/dev/null || true)
     rm -f .radia-run-jupyter-token
     if [[ $t ]]; then
-        echo "c.NotebookApp.token = '$t'" >> $HOME/.jupyter/jupyter_notebook_config.py
+        echo "c.ServerApp.token = '$t'" >> $HOME/.jupyter/jupyter_server_config.py
         cat <<EOF
 To connect to Jupyter, open:
 


### PR DESCRIPTION
This is the proper incantation for using jupyter server, lab, and hub

labhub mixes in a jupyter_server.serverapp.ServerApp
https://github.com/jupyterlab/jupyterlab/blob/239398c7ffdc37a169d584b5fb3ea9068a71c983/jupyterlab/labhubapp.py
with a singleuser_app.

Just calling jupyterhub-singleuser directly uses make_singleuser_app
which has no knowledge of the new jupyter_server so the configuration
specified in jupyter_server_config.py (allowed_kernelspecs) was not
being picked up.

Also fix #29. jupyter-server was released in #53 but this actually
uses it.