### PR TITLE
Fix radiasoft/download#321: Do not install extensions to circumvent i…

### DIFF
--- a/container-conf/build.sh
+++ b/container-conf/build.sh
@@ -65,13 +65,15 @@ beamsim_jupyter_jupyterlab() {
     )
     jupyter labextension install --no-build "${l[@]}"
     # https://jupyterlab.readthedocs.io/en/stable/user/jupyterhub.html#use-jupyterlab-by-default
-    beamsim_jupyter_lab
+    # git.radiasoft.org/download/issues/321
+    # Do not build until we upgrade to f36
+    # beamsim_jupyter_lab
     # Need dev-build because jupyter lab build defaults to dev build
     # when there are local extensions (jupyter-rs-*)
-    if ! jupyter lab build --dev-build=False; then
-        tail -100 /tmp/jupyterlab*.log || true
-        build_err 'juptyer lab failed to build'
-    fi
+    # if ! jupyter lab build --dev-build=False; then
+    #     tail -100 /tmp/jupyterlab*.log || true
+    #     build_err 'juptyer lab failed to build'
+    # fi
 }
 
 beamsim_jupyter_lab() {


### PR DESCRIPTION
…ssue with dependency

A transitive dependency (lib0) now requires node version >= 14. We only have
node 12 installed and are going to speed up the transition to fedora 36
which has a higher node version.