### PR TITLE
Fix #93: Fix dependencies

### DIFF
--- a/container-conf/build.sh
+++ b/container-conf/build.sh
@@ -21,9 +21,9 @@ beamsim_jupyter_jupyterlab() {
 	jupyterlab-widgets==1.0.2
 
         # modules users have requested
-        funcsigs
         llvmlite
         numba
+
         # needs to be before fbpic https://github.com/radiasoft/devops/issues/153
         pyfftw
         # https://github.com/radiasoft/devops/issues/152
@@ -38,9 +38,6 @@ beamsim_jupyter_jupyterlab() {
         safeopt
         # https://github.com/radiasoft/container-beamsim-jupyter/issues/13
         seaborn
-        # https://github.com/radiasoft/container-beamsim-jupyter/issues/38
-        torch
-        torchvision
         # https://github.com/radiasoft/container-beamsim-jupyter/issues/39
         botorch
         # needed by zgoubidoo


### PR DESCRIPTION
funcsigs is a backport of a python 3 feature to python 2. We no longer use python 2.

torch and torchvision are now installed in ml.sh so they don't need to be installed directly here.