### PR TITLE
Fix #105: Update lume-genesis

### DIFF
--- a/container-conf/build.sh
+++ b/container-conf/build.sh
@@ -47,6 +47,9 @@ beamsim_jupyter_base_jupyterlab() {
         # https://github.com/radiasoft/container-beamsim-jupyter-base/issues/32
         # installs bokeh, too
         git+https://github.com/slaclab/lume-genesis
+        eval-type-backport # lume-genesis missing dep
+        lark # lume-genesis missing dep
+        pydantic-settings # lume-genesis missing dep
         git+https://github.com/ChristopherMayes/openPMD-beamphysics
         git+https://github.com/radiasoft/zfel
 


### PR DESCRIPTION
lume-genesis expects a conda install which uses environment.yml to specify deps. We install using pip which looks at the pyproject.toml. The deps aren't specified in pyrpoject.toml so we have to explicitly install them.